### PR TITLE
Fixed incorrect math, more info inside:

### DIFF
--- a/mod.Lua
+++ b/mod.Lua
@@ -1,22 +1,20 @@
-
-local previous_total_xp = 0
-Hooks:PreHook(ExperienceManager, "mission_xp_award", "xp_notifier_before_xp_increase", function ()
-	previous_total_xp = get_current_total_xp()
-end)
-
-Hooks:PostHook(ExperienceManager, "mission_xp_award", "xp_notifier_after_xp_increase", function ()
-	local new_total_xp = get_current_total_xp()
-	local xp_added = new_total_xp - previous_total_xp
-	
-	local notification_text = xp_string(xp_added) .. " XP gained (Total XP: " .. xp_string(new_total_xp) .. ")"
-	managers.hud:show_hint({ text = notification_text })
-end)
-
-function get_current_total_xp()
-	local num_alive_players = managers.network:session():amount_of_alive_players()
-	return managers.experience:get_xp_dissected(true, num_alive_players, true)
-end
+local total_xp = 0 -- Create variables outside the hook, so we dont recreate them every hookcall
+local notification_text = ""
 
 function xp_string(n)
-	return managers.experience:experience_string(n)
+	if managers.experience ~= nil then -- Check for null/nil so we dont crash
+	   return managers.experience:experience_string(n)
+	else 
+	   return n
+	end
 end
+
+Hooks:PostHook(ExperienceManager, "mission_xp_award", "xp_notifier_after_xp_increase", function(self, amount)
+	total_xp = total_xp + amount
+	
+	notification_text = xp_string(amount) .. " XP gained (Total XP: " .. xp_string(total_xp) .. ")"
+	
+	if managers.hud ~= nil then
+	   managers.hud:show_hint({ text = notification_text })
+	end
+end)

--- a/mod.Lua
+++ b/mod.Lua
@@ -5,7 +5,7 @@ function xp_string(n)
 	if managers.experience ~= nil then -- Check for null/nil so we dont crash
 	   return managers.experience:experience_string(n)
 	else 
-	   return n
+	   return tostring(n)
 	end
 end
 


### PR DESCRIPTION
So I installed the newest version of xp-notifier and I saw that both the total xp and gained xp are calculated wrongly.

So I found this table: (https://payday.fandom.com/wiki/Reputation_(Payday_2)#Car_Shop)

![image](https://user-images.githubusercontent.com/44605473/120196118-c8964c80-c21f-11eb-9748-ef1d904d2cdd.png)

And I tested the xp with Your version, it was showing I got 5250 xp for planting all C4s, which was wrong, I fixed that and now it is showing the correct value of 3000 xp.

Also I added some null/nil checks so the users dont crash if PD2 updates.

I also removed the calculation of gained xp and replaced that by the "amount" parameter, also You should not recreate variables each hookcall, so I moved them out the hook and it is now only assigning new values every hookcall, should save some resources and performance.

I also removed the get_current_xp_total() function, since it made the total_xp calculation totally wrong and I replaced that with simple += stuff.