### PR TITLE
Stops a crash where it tries to show_hint when a player is not in a heist

### DIFF
--- a/mod.Lua
+++ b/mod.Lua
@@ -5,11 +5,13 @@ Hooks:PreHook(ExperienceManager, "mission_xp_award", "xp_notifier_before_xp_incr
 end)
 
 Hooks:PostHook(ExperienceManager, "mission_xp_award", "xp_notifier_after_xp_increase", function ()
-	local new_total_xp = get_current_total_xp()
-	local xp_added = new_total_xp - previous_total_xp
-	
-	local notification_text = xp_string(xp_added) .. " XP gained (Total XP: " .. xp_string(new_total_xp) .. ")"
-	managers.hud:show_hint({ text = notification_text })
+	if Utils:IsInHeist() then
+		local new_total_xp = get_current_total_xp()
+		local xp_added = new_total_xp - previous_total_xp
+		
+		local notification_text = xp_string(xp_added) .. " XP gained (Total XP: " .. xp_string(new_total_xp) .. ")"
+		managers.hud:show_hint({ text = notification_text })
+	end
 end)
 
 function get_current_total_xp()

--- a/mod.Lua
+++ b/mod.Lua
@@ -5,10 +5,10 @@ Hooks:PreHook(ExperienceManager, "mission_xp_award", "xp_notifier_before_xp_incr
 end)
 
 Hooks:PostHook(ExperienceManager, "mission_xp_award", "xp_notifier_after_xp_increase", function ()
-	if Utils:IsInHeist() then
-		local new_total_xp = get_current_total_xp()
-		local xp_added = new_total_xp - previous_total_xp
-		
+	local new_total_xp = get_current_total_xp()
+	local xp_added = new_total_xp - previous_total_xp
+
+	if managers.hud ~= nil then
 		local notification_text = xp_string(xp_added) .. " XP gained (Total XP: " .. xp_string(new_total_xp) .. ")"
 		managers.hud:show_hint({ text = notification_text })
 	end


### PR DESCRIPTION
This happens specifically on goat simulator, where you are given a xp value before the heist start, which triggers the hook and crashes the game when trying to render the hud_hint.