### PR TITLE
Fix Goat Sim day 1 crash

### DIFF
--- a/src/mod.Lua
+++ b/src/mod.Lua
@@ -33,10 +33,11 @@ function some_manager_is_missing()
 	local is_missing = managers.network == nil
 		or managers.experience == nil
 		or managers.hud == nil
+		or managers.hud._hud_hint == nil
 	if is_missing then
 		log("[XpNotifier] There's a manager missing!")
 	end
-	return 
+	return is_missing
 end
 
 function xp_string(n)


### PR DESCRIPTION
managers.hud was existing, but ._hud_hint was not existing yet, causing a crash on managers.hud:show_hint
also some_manager_is_missing wasn't returning is_missing